### PR TITLE
Add `.exhaustive` argument

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,9 @@
 
 * The arguments `preserve`, `default`, and `ordered` have been deprecated in favor of `.preserve`, `.default`, and `.ordered` (#9).
   - Using undotted arguments will now trigger a warning. In future versions, these arguments will be removed.
+* Functions in the `switch_case()`, `grep_case()`, and `fn_case()` families gain an `.exhaustive` argument (#11).
+  - When `.exhaustive` is `TRUE`, the function will throw an error if any elements of the input are not matched by case statements.
+    This can be useful to ensure you aren't accidentally forgetting to recode any values.
 * The position of the `.default` argument is now taken into account when setting factor levels in `*_case_fct()` functions (#10).
   - e.g. if the `.default` argument is given before any case statements, the default value will be the first level of the factor;
   if the `.default` argument is positioned in between two case statements, the default value will be ordered in between the value of the two case statements.

--- a/R/fn_case.R
+++ b/R/fn_case.R
@@ -49,6 +49,7 @@ fn_case <- function(
   ...,
   .preserve = FALSE,
   .default = NA,
+  .exhaustive = FALSE,
   preserve = deprecated(),
   default = deprecated()
 ) {
@@ -63,6 +64,7 @@ fn_case <- function(
     x = x,
     .default = .default,
     .preserve = .preserve,
+    .exhaustive = .exhaustive,
     fn = fn,
     args = inputs$args,
     default_env = rlang::caller_env(),

--- a/R/fn_case.R
+++ b/R/fn_case.R
@@ -78,34 +78,3 @@ fn_case_setup <- function(dots) {
 
   list(fs = fs, args = args)
 }
-
-first_incase_frame <- function() {
-  frames <- sys.frames()
-
-  for (frame in frames) {
-    if (identical(environment(rlang::frame_fn(frame)), asNamespace("incase"))) {
-      return(frame)
-    }
-  }
-
-  rlang::current_env()
-}
-
-first_incase_frame_parent <- function() {
-  frames <- sys.frames()
-
-  for (i in seq_len(sys.nframe())) {
-    if (
-      identical(
-        environment(rlang::frame_fn(frames[[i]])),
-        asNamespace("incase")
-      )
-    ) {
-      parent <- sys.parents()[[i]]
-      if (parent == 0) return(rlang::global_env())
-      return(frames[[parent]])
-    }
-  }
-
-  rlang::caller_env()
-}

--- a/R/fn_case.R
+++ b/R/fn_case.R
@@ -68,7 +68,13 @@ fn_case <- function(
     fn = fn,
     args = inputs$args,
     default_env = rlang::caller_env(),
-    current_env = rlang::current_env()
+    current_env = if (
+      identical(environment(rlang::caller_fn()), asNamespace("incase"))
+    ) {
+      rlang::caller_env()
+    } else {
+      rlang::current_env()
+    }
   )
 }
 

--- a/R/fn_case.R
+++ b/R/fn_case.R
@@ -59,7 +59,12 @@ fn_case <- function(
   inputs <- fn_case_setup(dots)
 
   replace(
-    inputs$fs, x, .default, .preserve, fn, inputs$args,
+    fs = inputs$fs,
+    x = x,
+    .default = .default,
+    .preserve = .preserve,
+    fn = fn,
+    args = inputs$args,
     default_env = rlang::caller_env(),
     current_env = rlang::current_env()
   )

--- a/R/grep_case.R
+++ b/R/grep_case.R
@@ -40,15 +40,14 @@ grep_case <- function(
   preserve = deprecated(),
   default = deprecated()
 ) {
-  .preserve <- coalesce_deprecated(.preserve, preserve)
-  .default <- coalesce_deprecated(.default, default)
-
   fn_case(
     x = x,
     fn = grepl_any,
     ...,
     .preserve = .preserve,
-    .default = .default
+    .default = .default,
+    preserve = preserve,
+    default = default
   )
 }
 

--- a/R/grep_case.R
+++ b/R/grep_case.R
@@ -37,6 +37,7 @@ grep_case <- function(
   ...,
   .preserve = FALSE,
   .default = NA,
+  .exhaustive = FALSE,
   preserve = deprecated(),
   default = deprecated()
 ) {
@@ -46,6 +47,7 @@ grep_case <- function(
     ...,
     .preserve = .preserve,
     .default = .default,
+    .exhaustive = .exhaustive,
     preserve = preserve,
     default = default
   )

--- a/R/in_case.R
+++ b/R/in_case.R
@@ -71,8 +71,8 @@ in_case <- function(
     x = inputs$x,
     .default = .default,
     .preserve = .preserve,
-    default_env = rlang::caller_env(),
-    current_env = rlang::current_env()
+    default_env = first_incase_frame_parent(),
+    current_env = first_incase_frame()
   )
 }
 

--- a/R/in_case.R
+++ b/R/in_case.R
@@ -67,10 +67,10 @@ in_case <- function(
   inputs <- in_case_setup(dots, .preserve = .preserve, fn = "in_case")
 
   replace(
-    fs          = inputs$fs,
-    x           = inputs$x,
-    .default     = .default,
-    .preserve    = .preserve,
+    fs = inputs$fs,
+    x = inputs$x,
+    .default = .default,
+    .preserve = .preserve,
     default_env = rlang::caller_env(),
     current_env = rlang::current_env()
   )

--- a/R/in_case_fct.R
+++ b/R/in_case_fct.R
@@ -59,8 +59,8 @@ in_case_fct <- function(
     .preserve = .preserve,
     factor = TRUE,
     .ordered = .ordered,
-    default_env = rlang::caller_env(),
-    current_env = rlang::current_env(),
+    default_env = first_incase_frame_parent(),
+    current_env = first_incase_frame(),
     dots_idx = dots_idx,
     .default_idx = .default_idx
   )
@@ -79,12 +79,7 @@ switch_case_fct <- function(
   default = deprecated(),
   ordered = deprecated()
 ) {
-  .preserve <- coalesce_deprecated(.preserve, preserve)
-  .default <- coalesce_deprecated(.default, default)
-  .ordered <- coalesce_deprecated(.ordered, ordered)
-
   args <- as.list(rlang::current_call())[-1]
-  args <- dot_arg_names(args)
 
   eval.parent(rlang::call2("fn_case_fct", fn = `%in%`, !!!args))
 }
@@ -102,12 +97,7 @@ grep_case_fct <- function(
   default = deprecated(),
   ordered = deprecated()
 ) {
-  .preserve <- coalesce_deprecated(.preserve, preserve)
-  .default <- coalesce_deprecated(.default, default)
-  .ordered <- coalesce_deprecated(.ordered, ordered)
-
   args <- as.list(rlang::current_call())[-1]
-  args <- dot_arg_names(args)
 
   eval.parent(rlang::call2("fn_case_fct", fn = grepl_any, !!!args))
 }
@@ -146,8 +136,8 @@ fn_case_fct <- function(
     args = inputs$args,
     factor = TRUE,
     .ordered = .ordered,
-    default_env = rlang::caller_env(),
-    current_env = rlang::current_env(),
+    default_env = first_incase_frame_parent(),
+    current_env = first_incase_frame(),
     dots_idx = dots_idx,
     .default_idx = .default_idx
   )
@@ -167,21 +157,5 @@ fn_switch_case_fct <- function(
   default = deprecated(),
   ordered = deprecated()
 ) {
-  .preserve <- coalesce_deprecated(.preserve, preserve)
-  .default <- coalesce_deprecated(.default, default)
-  .ordered <- coalesce_deprecated(.ordered, ordered)
-
   eval.parent(fn_switch_case_call("switch_case_fct", fn, ...))
-}
-
-dot_arg_names <- function(args) {
-  rlang::names2(args) <- switch_case(
-    rlang::names2(args),
-    "preserve" ~ ".preserve",
-    "default" ~ ".default",
-    "ordered" ~ ".ordered",
-    .preserve = TRUE
-  )
-
-  args
 }

--- a/R/in_case_fct.R
+++ b/R/in_case_fct.R
@@ -53,12 +53,12 @@ in_case_fct <- function(
   inputs <- in_case_setup(dots, .preserve = .preserve, fn = "in_case_fct")
 
   replace(
-    fs          = inputs$fs,
-    x           = inputs$x,
-    .default    = .default,
-    .preserve   = .preserve,
-    factor      = TRUE,
-    .ordered    = .ordered,
+    fs = inputs$fs,
+    x = inputs$x,
+    .default = .default,
+    .preserve = .preserve,
+    factor = TRUE,
+    .ordered = .ordered,
     default_env = rlang::caller_env(),
     current_env = rlang::current_env(),
     dots_idx = dots_idx,
@@ -138,7 +138,12 @@ fn_case_fct <- function(
   inputs <- fn_case_setup(dots)
 
   replace(
-    inputs$fs, x, .default, .preserve, fn, inputs$args,
+    fs = inputs$fs,
+    x = x,
+    .default = .default,
+    .preserve = .preserve,
+    fn = fn,
+    args = inputs$args,
     factor = TRUE,
     .ordered = .ordered,
     default_env = rlang::caller_env(),

--- a/R/in_case_fct.R
+++ b/R/in_case_fct.R
@@ -75,6 +75,7 @@ switch_case_fct <- function(
   .preserve = FALSE,
   .default = NA,
   .ordered = FALSE,
+  .exhaustive = FALSE,
   preserve = deprecated(),
   default = deprecated(),
   ordered = deprecated()
@@ -93,6 +94,7 @@ grep_case_fct <- function(
   .preserve = FALSE,
   .default = NA,
   .ordered = FALSE,
+  .exhaustive = FALSE,
   preserve = deprecated(),
   default = deprecated(),
   ordered = deprecated()
@@ -112,6 +114,7 @@ fn_case_fct <- function(
   .preserve = FALSE,
   .default = NA,
   .ordered = FALSE,
+  .exhaustive = FALSE,
   preserve = deprecated(),
   default = deprecated(),
   ordered = deprecated()
@@ -132,6 +135,7 @@ fn_case_fct <- function(
     x = x,
     .default = .default,
     .preserve = .preserve,
+    .exhaustive = .exhaustive,
     fn = fn,
     args = inputs$args,
     factor = TRUE,
@@ -153,6 +157,7 @@ fn_switch_case_fct <- function(
   .preserve = FALSE,
   .default = NA,
   .ordered = FALSE,
+  .exhaustive = FALSE,
   preserve = deprecated(),
   default = deprecated(),
   ordered = deprecated()

--- a/R/in_case_list.R
+++ b/R/in_case_list.R
@@ -51,6 +51,7 @@ switch_case_list <- function(
   ...,
   .preserve = FALSE,
   .default = NA,
+  .exhaustive = FALSE,
   preserve = deprecated(),
   default = deprecated()
 ) {
@@ -60,6 +61,7 @@ switch_case_list <- function(
     ...,
     .preserve = .preserve,
     .default = .default,
+    .exhaustive = .exhaustive,
     preserve = preserve,
     default = default,
   )
@@ -73,6 +75,7 @@ grep_case_list <- function(
   ...,
   .preserve = FALSE,
   .default = NA,
+  .exhaustive = FALSE,
   preserve = deprecated(),
   default = deprecated()
 ) {
@@ -82,6 +85,7 @@ grep_case_list <- function(
     ...,
     .preserve = .preserve,
     .default  = .default,
+    .exhaustive = .exhaustive,
     preserve = preserve,
     default = default,
   )
@@ -96,6 +100,7 @@ fn_case_list <- function(
   ...,
   .preserve = FALSE,
   .default = NA,
+  .exhaustive = FALSE,
   preserve = deprecated(),
   default = deprecated()
 ) {
@@ -110,6 +115,7 @@ fn_case_list <- function(
     x = x,
     .default = .default,
     .preserve = .preserve,
+    .exhaustive = .exhaustive,
     fn = fn,
     args = inputs$args,
     list = TRUE,
@@ -127,6 +133,7 @@ fn_switch_case_list <- function(
   ...,
   .preserve = FALSE,
   .default = NA,
+  .exhaustive = FALSE,
   preserve = deprecated(),
   default = deprecated()
 ) {

--- a/R/in_case_list.R
+++ b/R/in_case_list.R
@@ -33,8 +33,11 @@ in_case_list <- function(
   inputs <- in_case_setup(dots, .preserve = .preserve, fn = "in_case_list")
 
   replace(
-    inputs$fs, inputs$x, .default, .preserve,
-    list        = TRUE,
+    fs = inputs$fs,
+    x = inputs$x,
+    .default = .default,
+    .preserve = .preserve,
+    list = TRUE,
     default_env = rlang::caller_env(),
     current_env = rlang::current_env()
   )
@@ -105,7 +108,13 @@ fn_case_list <- function(
   inputs <- fn_case_setup(dots)
 
   replace(
-    inputs$fs, x, .default, .preserve, fn, inputs$args, list = TRUE,
+    fs = inputs$fs,
+    x = x,
+    .default = .default,
+    .preserve = .preserve,
+    fn = fn,
+    args = inputs$args,
+    list = TRUE,
     default_env = rlang::caller_env(),
     current_env = rlang::current_env()
   )

--- a/R/in_case_list.R
+++ b/R/in_case_list.R
@@ -38,8 +38,8 @@ in_case_list <- function(
     .default = .default,
     .preserve = .preserve,
     list = TRUE,
-    default_env = rlang::caller_env(),
-    current_env = rlang::current_env()
+    default_env = first_incase_frame_parent(),
+    current_env = first_incase_frame()
   )
 }
 
@@ -54,15 +54,14 @@ switch_case_list <- function(
   preserve = deprecated(),
   default = deprecated()
 ) {
-  .preserve <- coalesce_deprecated(.preserve, preserve)
-  .default <- coalesce_deprecated(.default, default)
-
   fn_case_list(
     x  = x,
     fn = `%in%`,
     ...,
     .preserve = .preserve,
-    .default  = .default
+    .default = .default,
+    preserve = preserve,
+    default = default,
   )
 }
 
@@ -77,15 +76,14 @@ grep_case_list <- function(
   preserve = deprecated(),
   default = deprecated()
 ) {
-  .preserve <- coalesce_deprecated(.preserve, preserve)
-  .default <- coalesce_deprecated(.default, default)
-
   fn_case_list(
     x  = x,
     fn = function(x, pattern, ...) grepl(pattern, x, ...),
     ...,
     .preserve = .preserve,
-    .default  = .default
+    .default  = .default,
+    preserve = preserve,
+    default = default,
   )
 }
 
@@ -115,8 +113,8 @@ fn_case_list <- function(
     fn = fn,
     args = inputs$args,
     list = TRUE,
-    default_env = rlang::caller_env(),
-    current_env = rlang::current_env()
+    default_env = first_incase_frame_parent(),
+    current_env = first_incase_frame()
   )
 }
 
@@ -132,8 +130,5 @@ fn_switch_case_list <- function(
   preserve = deprecated(),
   default = deprecated()
 ) {
-  .preserve <- coalesce_deprecated(.preserve, preserve)
-  .default <- coalesce_deprecated(.default, default)
-
   eval.parent(fn_switch_case_call("switch_case_list", fn, ...))
 }

--- a/R/replace.R
+++ b/R/replace.R
@@ -80,7 +80,7 @@ replace <- function(
     cli::cli_abort(
       c(
         "Not all values were matched.",
-        "x" = "The following values were not matched: {unique(x[!replaced])}.",
+        "x" = "The following {plu::ral('value was', unique(x[!replaced]))} not matched: {unique(x[!replaced])}.",
         "i" = "This error was generated because {.arg .exhaustive} is {.val {TRUE}}.",
         " " = "If you don't care about matching all values, you can set {.arg .exhaustive} to {.val {FALSE}}."
       ),

--- a/R/replace.R
+++ b/R/replace.R
@@ -5,6 +5,7 @@ replace <- function(
   x,
   .default,
   .preserve,
+  .exhaustive = FALSE,
   fn = NULL,
   args = NULL,
   factor = FALSE,
@@ -73,6 +74,18 @@ replace <- function(
     out <- replace_with(out, pairs$query[[i]] & !replaced, pairs$value[[i]])
     replaced <- replaced | (pairs$query[[i]] & !is.na(pairs$query[[i]]))
     if (all(replaced)) break
+  }
+
+  if (.exhaustive & !all(replaced)) {
+    cli::cli_abort(
+      c(
+        "Not all values were matched.",
+        "x" = "The following values were not matched: {unique(x[!replaced])}.",
+        "i" = "This error was generated because {.arg .exhaustive} is {.val {TRUE}}.",
+        " " = "If you don't care about matching all values, you can set {.arg .exhaustive} to {.val {FALSE}}."
+      ),
+      call = current_env
+    )
   }
 
   if (factor) {

--- a/R/switch_case.R
+++ b/R/switch_case.R
@@ -85,6 +85,7 @@ fn_switch_case <- function(
   ...,
   .preserve = FALSE,
   .default = NA,
+  .exhaustive = FALSE,
   preserve = deprecated(),
   default = deprecated()
 ) {

--- a/R/switch_case.R
+++ b/R/switch_case.R
@@ -25,6 +25,16 @@
 #' @param .default If `.preserve` is `FALSE`, a value to replace unmatched
 #'   elements of `x`.
 #'   Defaults to `NA`.
+#'
+#' @param .exhaustive If `TRUE`, unmatched elements of `x` will result in
+#'   an error.
+#'   This can be useful to ensure you aren't accidentally forgetting to recode
+#'   any values.
+#'   Defaults to `FALSE`.
+#'
+#'   Note that if `.preserve` is `TRUE`,
+#'   `.exhaustive` will never have any effect.
+#'
 #' @param preserve,default `r lifecycle::badge("deprecated")`
 #'   Deprecated in favor of `.preserve` and `.default`
 #'
@@ -50,6 +60,7 @@ switch_case <- function(
   ...,
   .preserve = FALSE,
   .default = NA,
+  .exhaustive = FALSE,
   preserve = deprecated(),
   default = deprecated()
 ) {
@@ -61,7 +72,8 @@ switch_case <- function(
     fn = `%in%`,
     ...,
     .preserve = .preserve,
-    .default  = .default
+    .default  = .default,
+    .exhaustive = .exhaustive
   )
 }
 

--- a/R/switch_case.R
+++ b/R/switch_case.R
@@ -64,16 +64,15 @@ switch_case <- function(
   preserve = deprecated(),
   default = deprecated()
 ) {
-  .preserve <- coalesce_deprecated(.preserve, preserve)
-  .default <- coalesce_deprecated(.default, default)
-
   fn_case(
     x  = x,
     fn = `%in%`,
     ...,
     .preserve = .preserve,
     .default  = .default,
-    .exhaustive = .exhaustive
+    .exhaustive = .exhaustive,
+    preserve = preserve,
+    default = default
   )
 }
 
@@ -89,9 +88,6 @@ fn_switch_case <- function(
   preserve = deprecated(),
   default = deprecated()
 ) {
-  .preserve <- coalesce_deprecated(.preserve, preserve)
-  .default <- coalesce_deprecated(.default, default)
-
   eval.parent(fn_switch_case_call("switch_case", fn, ...))
 }
 
@@ -103,7 +99,6 @@ fn_switch_case_call <- function(
   current_fn = rlang::caller_fn()
 ) {
   args <- as.list(call)[-1]
-  args <- dot_arg_names(args)
 
   dots <- compact_list(...)
   dots_idx <- which(args %in% dots)

--- a/R/utils.R
+++ b/R/utils.R
@@ -34,8 +34,7 @@ first_incase_frame_parent <- function() {
       )
     ) {
       parent <- sys.parents()[[i]]
-      if (parent == 0) return(rlang::global_env())
-      return(frames[[parent]])
+      if (parent > 0) return(frames[[parent]])
     }
   }
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -6,7 +6,12 @@ compact_list <- function(...) {
   Filter(function(x) !is.null(x), rlang::list2(...))
 }
 
-coalesce_deprecated <- function(.argument, argument) {
+coalesce_deprecated <- function(
+  .argument,
+  argument,
+  .current_env = first_incase_frame(),
+  .caller_env = first_incase_frame_parent()
+) {
   .arg_name <- rlang::expr_text(rlang::enexpr(.argument))
   arg_name <- rlang::expr_text(rlang::enexpr(argument))
 
@@ -14,7 +19,7 @@ coalesce_deprecated <- function(.argument, argument) {
     return(.argument)
   }
 
-  call <- rlang::caller_call()
+  call <- rlang::frame_call(.current_env)
   fn_name <- rlang::call_name(call)
 
   if (.arg_name %in% names(call) & !identical(.argument, argument)) {
@@ -23,7 +28,7 @@ coalesce_deprecated <- function(.argument, argument) {
         "{.arg {arg_name}} and {.arg {(.arg_name)}} arguments cannot both be specified.",
         "*" = "Please only specify {.arg {(.arg_name)}}."
       ),
-      call = rlang::caller_env()
+      call = .current_env
     )
   }
 
@@ -31,8 +36,8 @@ coalesce_deprecated <- function(.argument, argument) {
     "0.3.3",
     glue::glue("{fn_name}({arg_name})"),
     glue::glue("{fn_name}({.arg_name})"),
-    env = rlang::caller_env(),
-    user_env = rlang::caller_env(2)
+    env = .current_env,
+    user_env = .caller_env
   )
 
   argument

--- a/R/utils.R
+++ b/R/utils.R
@@ -6,6 +6,42 @@ compact_list <- function(...) {
   Filter(function(x) !is.null(x), rlang::list2(...))
 }
 
+first_incase_frame <- function() {
+  frames <- sys.frames()
+
+  for (i in seq_len(sys.nframe() - 1)) {
+    if (
+      identical(
+        environment(rlang::frame_fn(frames[[i]])),
+        asNamespace("incase")
+      )
+    ) {
+      return(frames[[i]])
+    }
+  }
+
+  rlang::caller_env()
+}
+
+first_incase_frame_parent <- function() {
+  frames <- sys.frames()
+
+  for (i in seq_len(sys.nframe() - 1)) {
+    if (
+      identical(
+        environment(rlang::frame_fn(frames[[i]])),
+        asNamespace("incase")
+      )
+    ) {
+      parent <- sys.parents()[[i]]
+      if (parent == 0) return(rlang::global_env())
+      return(frames[[parent]])
+    }
+  }
+
+  rlang::global_env()
+}
+
 coalesce_deprecated <- function(
   .argument,
   argument,

--- a/man/fn_case.Rd
+++ b/man/fn_case.Rd
@@ -10,6 +10,7 @@ fn_case(
   ...,
   .preserve = FALSE,
   .default = NA,
+  .exhaustive = FALSE,
   preserve = deprecated(),
   default = deprecated()
 )
@@ -49,6 +50,15 @@ Defaults to \code{FALSE}.}
 \item{.default, default}{If \code{.preserve} is \code{FALSE}, a value to replace unmatched
 elements of \code{x}.
 Defaults to \code{NA}.}
+
+\item{.exhaustive}{If \code{TRUE}, unmatched elements of \code{x} will result in
+an error.
+This can be useful to ensure you aren't accidentally forgetting to recode
+any values.
+Defaults to \code{FALSE}.
+
+Note that if \code{.preserve} is \code{TRUE},
+\code{.exhaustive} will never have any effect.}
 }
 \value{
 A vector of length 1 or n, matching the length of the logical input

--- a/man/grep_case.Rd
+++ b/man/grep_case.Rd
@@ -9,6 +9,7 @@ grep_case(
   ...,
   .preserve = FALSE,
   .default = NA,
+  .exhaustive = FALSE,
   preserve = deprecated(),
   default = deprecated()
 )
@@ -38,6 +39,15 @@ Defaults to \code{FALSE}.}
 \item{.default, default}{If \code{.preserve} is \code{FALSE}, a value to replace unmatched
 elements of \code{x}.
 Defaults to \code{NA}.}
+
+\item{.exhaustive}{If \code{TRUE}, unmatched elements of \code{x} will result in
+an error.
+This can be useful to ensure you aren't accidentally forgetting to recode
+any values.
+Defaults to \code{FALSE}.
+
+Note that if \code{.preserve} is \code{TRUE},
+\code{.exhaustive} will never have any effect.}
 }
 \value{
 A vector of the same length as \code{x}.

--- a/man/in_case_fct.Rd
+++ b/man/in_case_fct.Rd
@@ -24,6 +24,7 @@ switch_case_fct(
   .preserve = FALSE,
   .default = NA,
   .ordered = FALSE,
+  .exhaustive = FALSE,
   preserve = deprecated(),
   default = deprecated(),
   ordered = deprecated()
@@ -35,6 +36,7 @@ grep_case_fct(
   .preserve = FALSE,
   .default = NA,
   .ordered = FALSE,
+  .exhaustive = FALSE,
   preserve = deprecated(),
   default = deprecated(),
   ordered = deprecated()
@@ -47,6 +49,7 @@ fn_case_fct(
   .preserve = FALSE,
   .default = NA,
   .ordered = FALSE,
+  .exhaustive = FALSE,
   preserve = deprecated(),
   default = deprecated(),
   ordered = deprecated()
@@ -59,6 +62,7 @@ fn_switch_case_fct(
   .preserve = FALSE,
   .default = NA,
   .ordered = FALSE,
+  .exhaustive = FALSE,
   preserve = deprecated(),
   default = deprecated(),
   ordered = deprecated()
@@ -96,6 +100,15 @@ If \code{\link{FALSE}}, returns an unordered factor.}
 Deprecated in favor of \code{.preserve}, \code{.default}, and \code{.ordered}}
 
 \item{x}{A vector}
+
+\item{.exhaustive}{If \code{TRUE}, unmatched elements of \code{x} will result in
+an error.
+This can be useful to ensure you aren't accidentally forgetting to recode
+any values.
+Defaults to \code{FALSE}.
+
+Note that if \code{.preserve} is \code{TRUE},
+\code{.exhaustive} will never have any effect.}
 
 \item{fn}{A function to apply to the left-hand side of each formula in \code{...}
 

--- a/man/in_case_list.Rd
+++ b/man/in_case_list.Rd
@@ -21,6 +21,7 @@ switch_case_list(
   ...,
   .preserve = FALSE,
   .default = NA,
+  .exhaustive = FALSE,
   preserve = deprecated(),
   default = deprecated()
 )
@@ -30,6 +31,7 @@ grep_case_list(
   ...,
   .preserve = FALSE,
   .default = NA,
+  .exhaustive = FALSE,
   preserve = deprecated(),
   default = deprecated()
 )
@@ -40,6 +42,7 @@ fn_case_list(
   ...,
   .preserve = FALSE,
   .default = NA,
+  .exhaustive = FALSE,
   preserve = deprecated(),
   default = deprecated()
 )
@@ -50,6 +53,7 @@ fn_switch_case_list(
   ...,
   .preserve = FALSE,
   .default = NA,
+  .exhaustive = FALSE,
   preserve = deprecated(),
   default = deprecated()
 )
@@ -79,6 +83,15 @@ elements of \code{x}.
 Defaults to \code{NA}.}
 
 \item{x}{A vector}
+
+\item{.exhaustive}{If \code{TRUE}, unmatched elements of \code{x} will result in
+an error.
+This can be useful to ensure you aren't accidentally forgetting to recode
+any values.
+Defaults to \code{FALSE}.
+
+Note that if \code{.preserve} is \code{TRUE},
+\code{.exhaustive} will never have any effect.}
 
 \item{fn}{A function to apply to the left-hand side of each formula in \code{...}
 

--- a/man/switch_case.Rd
+++ b/man/switch_case.Rd
@@ -21,6 +21,7 @@ fn_switch_case(
   ...,
   .preserve = FALSE,
   .default = NA,
+  .exhaustive = FALSE,
   preserve = deprecated(),
   default = deprecated()
 )

--- a/man/switch_case.Rd
+++ b/man/switch_case.Rd
@@ -10,6 +10,7 @@ switch_case(
   ...,
   .preserve = FALSE,
   .default = NA,
+  .exhaustive = FALSE,
   preserve = deprecated(),
   default = deprecated()
 )
@@ -50,6 +51,15 @@ Defaults to \code{FALSE}.}
 \item{.default}{If \code{.preserve} is \code{FALSE}, a value to replace unmatched
 elements of \code{x}.
 Defaults to \code{NA}.}
+
+\item{.exhaustive}{If \code{TRUE}, unmatched elements of \code{x} will result in
+an error.
+This can be useful to ensure you aren't accidentally forgetting to recode
+any values.
+Defaults to \code{FALSE}.
+
+Note that if \code{.preserve} is \code{TRUE},
+\code{.exhaustive} will never have any effect.}
 
 \item{preserve, default}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 Deprecated in favor of \code{.preserve} and \code{.default}}

--- a/tests/testthat/test-fn_case.R
+++ b/tests/testthat/test-fn_case.R
@@ -57,6 +57,29 @@ test_that("fn_case() ignore.case", {
   )
 })
 
+test_that("fn_case() exhaustive", {
+  expect_error(
+    fn_case(
+      words,
+      fn = function(x, pattern, ...) {grepl(pattern, x, ...)},
+      "cat" ~ "feline",
+      .exhaustive = TRUE
+    ),
+    "The following values were not matched: dogwood and dogma.",
+  )
+
+  expect_equal(
+    fn_case(
+      words,
+      fn = function(x, pattern, ...) {grepl(pattern, x, ...)},
+      "cat" ~ "feline",
+      "dog" ~ "canine",
+      .exhaustive = TRUE
+    ),
+    result
+  )
+})
+
 test_that("errors", {
   expect_error(fn_case(1:10, function(x) x < 5))
   expect_error(fn_case(1:10, function(x, y) {x + y}, 1 ~ TRUE, 2 ~ FALSE))

--- a/tests/testthat/test-grep_case.R
+++ b/tests/testthat/test-grep_case.R
@@ -21,6 +21,20 @@ test_that("grep_case() with ignore.case", {
   )
 })
 
+test_that("grep_case() .exhaustive", {
+  words <- c("caterpillar", "dogwood", "catastrophe", "dogma")
+
+  expect_error(
+    grep_case(words, "cat" ~ "feline", .exhaustive = TRUE),
+    "The following values were not matched: dogwood and dogma.",
+  )
+
+  expect_equal(
+    grep_case(words, "cat" ~ "feline", "dog" ~ "canine", .exhaustive = TRUE),
+    c("feline", "canine", "feline", "canine")
+  )
+})
+
 test_that("grep_case() with two args", {
   caps_words <- c("caterpillar", "dogwood", "Catastrophe", "DOGMA")
 

--- a/tests/testthat/test-in_case_fct.R
+++ b/tests/testthat/test-in_case_fct.R
@@ -585,6 +585,34 @@ test_that("fn_switch_case_fct() with arguments and default", {
   )
 })
 
+test_that("exhaustive *_case_fct()", {
+  error <- expect_error(
+    switch_case_fct(
+      c("a", "b", "c"),
+      "c" ~ "cantaloupe",
+      "b" ~ "banana",
+      .exhaustive = TRUE
+    ),
+    "The following value was not matched: a.",
+  )
+
+  expect_equal(error$call[[1]], rlang::sym("switch_case_fct"))
+
+  expect_equal(
+    switch_case_fct(
+      c("a", "b", "c"),
+      "c" ~ "cantaloupe",
+      "b" ~ "banana",
+      "a" ~ "apple",
+      .exhaustive = TRUE
+    ),
+    factor(
+      c("apple", "banana", "cantaloupe"),
+      levels = c("cantaloupe", "banana", "apple")
+    )
+  )
+})
+
 test_that("fn_switch_case_fct() errors", {
   expect_error(fn_switch_case_fct(1:10, function(x) x + 5))
 })

--- a/tests/testthat/test-in_case_list.R
+++ b/tests/testthat/test-in_case_list.R
@@ -46,6 +46,20 @@ test_that("switch_case_list", {
   )
 })
 
+test_that("exhaustive switch_case_list", {
+  error <- expect_error(
+    1:3 %>% switch_case_list(2 ~ mtcars, .exhaustive = TRUE),
+    "The following values were not matched: 1 and 3.",
+  )
+
+  expect_equal(error$call[[1]], rlang::sym("switch_case_list"))
+
+  expect_equal(
+    1:3 %>% switch_case_list(2 ~ mtcars, 1:3 ~ letters, .exhaustive = TRUE),
+    list(letters, mtcars, letters)
+  )
+})
+
 test_that("grep_case_list", {
   names <- c("bat", "cat", "dog")
 
@@ -58,6 +72,22 @@ test_that("grep_case_list", {
     dplyr::tibble(x = names) %>%
       dplyr::mutate(y = grep_case_list(x, "a" ~ mtcars, .default = letters)),
     dplyr::tibble(x = names, y = list(mtcars, mtcars, letters))
+  )
+})
+
+test_that("exhaustive grep_case_list", {
+  names <- c("bat", "cat", "dog")
+
+  error <- expect_error(
+    names %>% grep_case_list("a" ~ mtcars, .exhaustive = TRUE),
+    "The following value was not matched: dog.",
+  )
+
+  expect_equal(error$call[[1]], rlang::sym("grep_case_list"))
+
+  expect_equal(
+    names %>% grep_case_list("a" ~ mtcars, "o" ~ letters, .exhaustive = TRUE),
+    list(mtcars, mtcars, letters)
   )
 })
 
@@ -107,6 +137,38 @@ test_that("fn_switch_case_list()", {
       8 ~ letters,
       9 ~ mtcars,
       .preserve = TRUE
+    ),
+    list(1, 2, mtcars, letters, mtcars)
+  )
+})
+
+test_that("exhaustive grep_case_list", {
+  data <- c(111, 222, 999, 888, 777)
+
+  error <- expect_error(
+    fn_switch_case_list(
+      data,
+      function(x) strrep(x, 3),
+      7 ~ mtcars,
+      8 ~ letters,
+      9 ~ mtcars,
+      .exhaustive = TRUE
+    ),
+    "The following values were not matched: 111 and 222.",
+  )
+
+  expect_equal(error$call[[1]], rlang::sym("fn_switch_case_list"))
+
+  expect_equal(
+    fn_switch_case_list(
+      data,
+      function(x) strrep(x, 3),
+      1 ~ 1,
+      2 ~ 2,
+      7 ~ mtcars,
+      8 ~ letters,
+      9 ~ mtcars,
+      .exhaustive = TRUE
     ),
     list(1, 2, mtcars, letters, mtcars)
   )

--- a/tests/testthat/test-switch_case.R
+++ b/tests/testthat/test-switch_case.R
@@ -1,7 +1,7 @@
-yn <- c(NA, NA, "fizz", NA, "buzz", "fizz", NA, NA, "fizz", NA)
-yp <- c(1, 2, "fizz", 4, "buzz", "fizz", 7, 8, "fizz", 10)
+yn <- c(NA, NA, "fizz", NA, "buzz", "fizz", NA, NA, "fizz", "buzz")
+yp <- c(1, 2, "fizz", 4, "buzz", "fizz", 7, 8, "fizz", "buzz")
 yd <- c(
-  "bam", "bam", "fizz", "bam", "buzz", "fizz", "bam", "bam", "fizz", "bam"
+  "bam", "bam", "fizz", "bam", "buzz", "fizz", "bam", "bam", "fizz", "buzz"
 )
 
 test_that("unpiped unpreserved switch_case()", {
@@ -11,6 +11,7 @@ test_that("unpiped unpreserved switch_case()", {
     5 ~ "buzz",
     6 ~ "fizz",
     9 ~ "fizz",
+    10 ~ "buzz",
     .preserve = FALSE
   )
 
@@ -21,7 +22,8 @@ test_that("unpiped unpreserved switch_case()", {
     3 ~ "fizz",
     5 ~ "buzz",
     6 ~ "fizz",
-    9 ~ "fizz"
+    9 ~ "fizz",
+    10 ~ "buzz"
   )
 
   expect_equal(x, yn)
@@ -34,6 +36,7 @@ test_that("unpiped preserved switch_case()", {
     5 ~ "buzz",
     6 ~ "fizz",
     9 ~ "fizz",
+    10 ~ "buzz",
     .preserve = TRUE
   )
 
@@ -47,6 +50,7 @@ test_that("unpiped defaulted switch_case()", {
     5 ~ "buzz",
     6 ~ "fizz",
     9 ~ "fizz",
+    10 ~ "buzz",
     .default = "bam"
   )
 
@@ -57,7 +61,7 @@ test_that("unpiped vectored switch_case()", {
   x <- switch_case(
     1:10,
     c(3, 6, 9) ~ "fizz",
-    5          ~ "buzz"
+    c(5, 10) ~ "buzz"
   )
 
   expect_equal(x, yn)
@@ -70,6 +74,7 @@ test_that("piped unpreserved switch_case()", {
       5 ~ "buzz",
       6 ~ "fizz",
       9 ~ "fizz",
+      10 ~ "buzz",
       .preserve = FALSE
     )
 
@@ -80,7 +85,8 @@ test_that("piped unpreserved switch_case()", {
       3 ~ "fizz",
       5 ~ "buzz",
       6 ~ "fizz",
-      9 ~ "fizz"
+      9 ~ "fizz",
+      10 ~ "buzz"
     )
 
   expect_equal(x, yn)
@@ -93,6 +99,7 @@ test_that("piped preserved switch_case()", {
       5 ~ "buzz",
       6 ~ "fizz",
       9 ~ "fizz",
+      10 ~ "buzz",
       .preserve = TRUE
     )
 
@@ -106,6 +113,7 @@ test_that("piped defaulted switch_case()", {
       5 ~ "buzz",
       6 ~ "fizz",
       9 ~ "fizz",
+      10 ~ "buzz",
       .default = "bam"
     )
 
@@ -116,7 +124,7 @@ test_that("unpiped vectored switch_case()", {
   x <- 1:10 %>%
     switch_case(
       c(3, 6, 9) ~ "fizz",
-      5          ~ "buzz"
+      c(5, 10) ~ "buzz"
     )
 
   expect_equal(x, yn)
@@ -185,6 +193,7 @@ test_that("warning for deprecated argument", {
       5 ~ "buzz",
       6 ~ "fizz",
       9 ~ "fizz",
+      10 ~ "buzz",
       preserve = FALSE
     ),
     "The `preserve` argument of `switch_case()` is deprecated as of incase 0.3.3.",
@@ -199,6 +208,7 @@ test_that("warning for deprecated argument", {
       5 ~ "buzz",
       6 ~ "fizz",
       9 ~ "fizz",
+      10 ~ "buzz",
       .preserve = FALSE
     )
   )
@@ -210,6 +220,7 @@ test_that("warning for deprecated argument", {
       5 ~ "buzz",
       6 ~ "fizz",
       9 ~ "fizz",
+      10 ~ "buzz",
       default = "bam"
     ),
     "The `default` argument of `switch_case()` is deprecated as of incase 0.3.3.",
@@ -224,6 +235,7 @@ test_that("warning for deprecated argument", {
       5 ~ "buzz",
       6 ~ "fizz",
       9 ~ "fizz",
+      10 ~ "buzz",
       .default = "bam"
     )
   )

--- a/tests/testthat/test-switch_case.R
+++ b/tests/testthat/test-switch_case.R
@@ -130,9 +130,8 @@ test_that("unpiped vectored switch_case()", {
   expect_equal(x, yn)
 })
 
-
 test_that("exhaustive switch_case()", {
-  expect_error(
+  error <- expect_error(
     switch_case(
       1:10,
       c(3, 6, 9) ~ "fizz",
@@ -142,6 +141,8 @@ test_that("exhaustive switch_case()", {
     "The following values were not matched: 1, 2, 4, 7, and 8.",
     fixed = TRUE
   )
+
+  expect_equal(error$call[[1]], rlang::sym("switch_case"))
 
   expect_equal(
     switch_case(
@@ -214,6 +215,38 @@ test_that("fn_switch_case()", {
       .preserve = TRUE
     ),
     c("1", "2", "Missing", "Refused", "Not asked")
+  )
+})
+
+test_that("fn_switch_case() exhaustive", {
+  data <- c(1, 2, 999, 888, 777)
+
+  error <- expect_error(
+    fn_switch_case(
+      data,
+      function(x) strrep(x, 3),
+      7 ~ "Not asked",
+      8 ~ "Refused",
+      9 ~ "Missing",
+      .exhaustive = TRUE
+    ),
+    "The following values were not matched: 1 and 2.",
+    fixed = TRUE
+  )
+
+  expect_equal(error$call[[1]], rlang::sym("fn_switch_case"))
+
+  expect_equal(
+    fn_switch_case(
+      c(111, 222, 999, 888, 777),
+      function(x) strrep(x, 3),
+      1:2 ~ "Valid",
+      7 ~ "Not asked",
+      8 ~ "Refused",
+      9 ~ "Missing",
+      .exhaustive = TRUE
+    ),
+    c("Valid", "Valid", "Missing", "Refused", "Not asked")
   )
 })
 

--- a/tests/testthat/test-switch_case.R
+++ b/tests/testthat/test-switch_case.R
@@ -130,6 +130,42 @@ test_that("unpiped vectored switch_case()", {
   expect_equal(x, yn)
 })
 
+
+test_that("exhaustive switch_case()", {
+  expect_error(
+    switch_case(
+      1:10,
+      c(3, 6, 9) ~ "fizz",
+      c(5, 10) ~ "buzz",
+      .exhaustive = TRUE
+    ),
+    "The following values were not matched: 1, 2, 4, 7, and 8.",
+    fixed = TRUE
+  )
+
+  expect_equal(
+    switch_case(
+      1:10,
+      c(3, 6, 9) ~ "fizz",
+      c(5, 10) ~ "buzz",
+      1:10 ~ "bam",
+      .exhaustive = TRUE
+    ),
+    yd
+  )
+
+  expect_equal(
+    switch_case(
+      1:10,
+      c(3, 6, 9) ~ "fizz",
+      c(5, 10) ~ "buzz",
+      .preserve = TRUE,
+      .exhaustive = TRUE
+    ),
+    c(1, 2, "fizz", 4, "buzz", "fizz", 7, 8, "fizz", "buzz")
+  )
+})
+
 test_that("default from other variable switch_case()", {
   input  <- dplyr::tibble(a = letters[1:5], b = 1:5)
   output <- dplyr::tibble(a = letters[1:5], b = 1:5, c = c(10, 2:5))

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -1,0 +1,11 @@
+test_that("first_incase_frame()", {
+  expect_equal(
+    first_incase_frame(),
+    rlang::current_env()
+  )
+
+  expect_equal(
+    first_incase_frame_parent(),
+    rlang::global_env()
+  )
+})


### PR DESCRIPTION
Functions in the `switch_case()`, `grep_case()`, and `fn_case()` families gain an `.exhaustive` argument.

When `.exhaustive` is `TRUE`, the function will throw an error if any elements of the input are not matched by case statements. This can be useful to ensure you aren't accidentally forgetting to recode any values.